### PR TITLE
前期の表示に対応＋現在の学期に合わせて授業を表示するロジックを作成

### DIFF
--- a/timetable.js
+++ b/timetable.js
@@ -3560,25 +3560,38 @@ function isElementIncluded(targetElement) {
     return lectureIdSet.has(targetElement);
 }
 
+// 今が前期かを判別する関数
+function isFirstSemester(date = new Date()) {
+	const month = date.getMonth() + 1; // getMonth() は 0（1月）〜11（12月）を返す
+	return month >= 4 && month <= 8;
+}
+
 async function showTimeTable() {
     // トップページか確認
     if (document.querySelector("#col2of2 > div > nav > h2")?.textContent !== '大学からのお知らせ') {
         return;
     }
     const classSchedules = await getDayAndPeriod();
-    const nowLecture = [];
+	const nowLecture = [];
 
-    classSchedules.forEach(lecture => {
-        // 前期以外の授業のみ取得(2024後期対応用)
-        if (!isElementIncluded(lecture.classCode)) {
-            nowLecture.push({
-                title: lecture.lectureName,
-                link: lecture.link,
-                lecture_id: lecture.classCode,
-                timeTable: lecture.timeTable
-            });
-        }
-    });
+	const semester = isFirstSemester() ? "first" : "second";
+
+	classSchedules.forEach((lecture) => {
+
+		const isFirstSemesterLecture = isElementIncluded(lecture.classCode);
+        const isDisplayLecture =
+			(semester === "first" && isFirstSemesterLecture) ||
+			(semester === "second" && !isFirstSemesterLecture);
+
+		if (isDisplayLecture) {
+			nowLecture.push({
+				title: lecture.lectureName,
+				link: lecture.link,
+				lecture_id: lecture.classCode,
+				timeTable: lecture.timeTable
+			});
+		}
+	});
     
     createScheduleTable(nowLecture);
 }


### PR DESCRIPTION
# 概要
前期の時間割が表示されるように修正しました．
また，現在時刻を取得して前期と後期の判別を行い，適切な学期の授業情報が表示されるロジックを追加しました．

# 変更内容
- 現在が前期かをbool値で返す関数`isFirstSemester`の実装
- 表示する授業かを判別するループ(3571行目-3581行目)で，上記関数を用いた実装を行いました．

# 動作確認
手元の環境で2025年前期の授業が表示できていることを確認しました．
![image](https://github.com/user-attachments/assets/de96ee78-1eb2-4d99-bef3-a90c74911a4a)


また，3564行目を`function isFirstSemester(date = new Date("2025-11-01")) {`と書き換えたとき，本PRの前のコードと同じ挙動を示していることを確認しました．
![image](https://github.com/user-attachments/assets/4361abbe-97d7-4d43-b180-9750eb1d2c85)

# 備考
現在，コード全体をまだ確認できておらず，表示する授業かを判別するループ(3571行目-3581行目)内の処理の書き換えで対応いたしました．

よろしくお願いいたします．